### PR TITLE
port build to sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,20 @@
+parallelExecution in ThisBuild := false
+
+lazy val threetenbp = project.in(file("."))
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.scalatest" %%% "scalatest" % "3.0.0-M15" % "test",
+      "junit" % "junit" % "4.12" % "test",
+      "org.testng" % "testng" % "6.8.8" % "test"
+    ),
+    name := "threetenbp",
+    organization := "org.threeten",
+    scalaVersion := "2.11.7",
+    version := "1.3.3-SNAPSHOT",
+    isSnapshot := true,
+    scalacOptions ++= Seq("-Xexperimental")
+  )
+
+//lazy val threetenbpJVM = threetenbp.jvm
+//
+//lazy val threetenbpJS = threetenbp.js

--- a/pom.xml
+++ b/pom.xml
@@ -453,6 +453,12 @@
       <version>2.11.7</version>
     </dependency>
     <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_2.11</artifactId>
+      <version>3.0.0-M15</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>6.8</version>
@@ -656,7 +662,7 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>      
+            <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.2.1</version>
             <executions>
@@ -693,7 +699,7 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>      
+            <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.2.1</version>
             <executions>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.7")

--- a/src/test/scala/org/threeten/bp/AbstractDateTimeTest.scala
+++ b/src/test/scala/org/threeten/bp/AbstractDateTimeTest.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.fail
 import org.testng.annotations.Test
@@ -40,21 +41,24 @@ import org.threeten.bp.temporal.TemporalField
 /**
   * Base test class for {@code DateTime}.
   */
-abstract class AbstractDateTimeTest {
+abstract class AbstractDateTimeTest extends TestNGSuite {
   /**
     * Sample {@code DateTime} objects.
+ *
     * @return the objects, not null
     */
   protected def samples: java.util.List[TemporalAccessor]
 
   /**
     * List of valid supported fields.
+ *
     * @return the fields, not null
     */
   protected def validFields: java.util.List[TemporalField]
 
   /**
     * List of invalid unsupported fields.
+ *
     * @return the fields, not null
     */
   protected def invalidFields: java.util.List[TemporalField]

--- a/src/test/scala/org/threeten/bp/AbstractTest.scala
+++ b/src/test/scala/org/threeten/bp/AbstractTest.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertSame
 import org.testng.Assert.assertTrue
@@ -49,7 +50,7 @@ import java.lang.reflect.Modifier
 /**
   * Base test class.
   */
-object AbstractTest {
+object AbstractTest extends TestNGSuite {
   private val SERIALISATION_DATA_FOLDER: String = "src/test/resources/"
 
   def isIsoLeap(year: Long): Boolean =

--- a/src/test/scala/org/threeten/bp/Performance.scala
+++ b/src/test/scala/org/threeten/bp/Performance.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp
 
+import org.scalatest.testng.TestNGSuite
 import org.threeten.bp.temporal.ChronoField.DAY_OF_MONTH
 import org.threeten.bp.temporal.ChronoField.HOUR_OF_DAY
 import org.threeten.bp.temporal.ChronoField.MINUTE_OF_HOUR
@@ -57,7 +58,7 @@ import org.threeten.bp.format.DateTimeFormatter
 /**
   * Test Performance.
   */
-object Performance {
+object Performance extends TestNGSuite {
   /** Size. */
   private val NF: NumberFormat = {
     val nf = NumberFormat.getIntegerInstance
@@ -73,6 +74,7 @@ object Performance {
 
   /**
     * Main.
+ *
     * @param args  the arguments
     */
   def main(args: Array[String]): Unit = {

--- a/src/test/scala/org/threeten/bp/TestClock.scala
+++ b/src/test/scala/org/threeten/bp/TestClock.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 
@@ -59,7 +60,7 @@ import org.testng.annotations.Test
   private val MOCK_INSTANT: Clock = new TestClock.MockInstantClock(INSTANT.toEpochMilli, ZONE)
 }
 
-@Test class TestClock {
+@Test class TestClock extends TestNGSuite {
   @Test def test_mockInstantClock_get(): Unit = {
     assertEquals(TestClock.MOCK_INSTANT.instant, TestClock.INSTANT)
     assertEquals(TestClock.MOCK_INSTANT.millis, TestClock.INSTANT.toEpochMilli)

--- a/src/test/scala/org/threeten/bp/TestClock_Fixed.scala
+++ b/src/test/scala/org/threeten/bp/TestClock_Fixed.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertSame
 import java.io.IOException
@@ -45,7 +46,7 @@ import org.testng.annotations.Test
   private val INSTANT: Instant = LocalDateTime.of(2008, 6, 30, 11, 30, 10, 500).atZone(ZoneOffset.ofHours(2)).toInstant
 }
 
-@Test class TestClock_Fixed {
+@Test class TestClock_Fixed extends TestNGSuite {
   @throws(classOf[IOException])
   @throws(classOf[ClassNotFoundException])
   def test_isSerializable(): Unit = {

--- a/src/test/scala/org/threeten/bp/TestClock_Offset.scala
+++ b/src/test/scala/org/threeten/bp/TestClock_Offset.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertSame
 import java.io.IOException
@@ -46,7 +47,7 @@ import org.testng.annotations.Test
   private val OFFSET: Duration = Duration.ofSeconds(2)
 }
 
-@Test class TestClock_Offset {
+@Test class TestClock_Offset extends TestNGSuite {
   @throws(classOf[IOException])
   @throws(classOf[ClassNotFoundException])
   def test_isSerializable(): Unit = {

--- a/src/test/scala/org/threeten/bp/TestClock_System.scala
+++ b/src/test/scala/org/threeten/bp/TestClock_System.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertSame
 import org.testng.Assert.fail
@@ -45,7 +46,7 @@ import org.testng.annotations.Test
   private val PARIS: ZoneId = ZoneId.of("Europe/Paris")
 }
 
-@Test class TestClock_System  {
+@Test class TestClock_System  extends TestNGSuite {
   @throws(classOf[IOException])
   @throws(classOf[ClassNotFoundException])
   def test_isSerializable(): Unit = {

--- a/src/test/scala/org/threeten/bp/TestClock_Tick.scala
+++ b/src/test/scala/org/threeten/bp/TestClock_Tick.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertSame
 import java.io.IOException
@@ -47,7 +48,7 @@ import org.testng.annotations.Test
   private val INSTANT: Instant = ZDT.toInstant
 }
 
-@Test class TestClock_Tick {
+@Test class TestClock_Tick extends TestNGSuite {
   @throws(classOf[IOException])
   @throws(classOf[ClassNotFoundException])
   def test_isSerializable(): Unit = {

--- a/src/test/scala/org/threeten/bp/TestDateTimes_implementation.scala
+++ b/src/test/scala/org/threeten/bp/TestDateTimes_implementation.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertTrue
 import java.lang.reflect.Modifier
@@ -41,7 +42,7 @@ import org.testng.annotations.Test
 /**
   * Test.
   */
-@Test class TestDateTimes_implementation {
+@Test class TestDateTimes_implementation extends TestNGSuite {
   @SuppressWarnings(Array("rawtypes"))
   @throws(classOf[Exception])
   def test_constructor(): Unit = {

--- a/src/test/scala/org/threeten/bp/TestDuration.scala
+++ b/src/test/scala/org/threeten/bp/TestDuration.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.fail
 import org.threeten.bp.temporal.ChronoUnit.DAYS
@@ -55,7 +56,7 @@ import org.threeten.bp.temporal.TemporalUnit
 /**
   * Test Duration.
   */
-@Test class TestDuration {
+@Test class TestDuration extends TestNGSuite {
   @Test def test_immutable(): Unit = {
     AbstractTest.assertImmutable(classOf[Duration])
   }

--- a/src/test/scala/org/threeten/bp/chrono/TestChronoLocalDate.scala
+++ b/src/test/scala/org/threeten/bp/chrono/TestChronoLocalDate.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.chrono
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertTrue
 import java.io.ByteArrayInputStream
@@ -181,7 +182,7 @@ import org.threeten.bp.temporal.ValueRange
 
 }
 
-@Test class TestChronoLocalDate {
+@Test class TestChronoLocalDate extends TestNGSuite {
   @DataProvider(name = "calendars") private[chrono] def data_of_calendars: Array[Array[Chronology]] = {
     Array[Array[Chronology]](Array(HijrahChronology.INSTANCE), Array(IsoChronology.INSTANCE), Array(JapaneseChronology.INSTANCE), Array(MinguoChronology.INSTANCE), Array(ThaiBuddhistChronology.INSTANCE))
   }

--- a/src/test/scala/org/threeten/bp/chrono/TestChronoLocalDateTime.scala
+++ b/src/test/scala/org/threeten/bp/chrono/TestChronoLocalDateTime.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.chrono
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertTrue
 import java.io.ByteArrayInputStream
@@ -175,7 +176,7 @@ import org.threeten.bp.temporal.ValueRange
 }
 
 @SuppressWarnings(Array("rawtypes"))
-@Test class TestChronoLocalDateTime {
+@Test class TestChronoLocalDateTime extends TestNGSuite {
   @DataProvider(name = "calendars") private[chrono] def data_of_calendars: Array[Array[Chronology]] = {
     Array[Array[Chronology]](Array(HijrahChronology.INSTANCE), Array(IsoChronology.INSTANCE), Array(JapaneseChronology.INSTANCE), Array(MinguoChronology.INSTANCE), Array(ThaiBuddhistChronology.INSTANCE))
   }

--- a/src/test/scala/org/threeten/bp/chrono/TestChronoZonedDateTime.scala
+++ b/src/test/scala/org/threeten/bp/chrono/TestChronoZonedDateTime.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.chrono
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertTrue
 import java.io.ByteArrayInputStream
@@ -187,7 +188,7 @@ import org.threeten.bp.temporal.ValueRange
 }
 
 @SuppressWarnings(Array("rawtypes"))
-@Test class TestChronoZonedDateTime {
+@Test class TestChronoZonedDateTime extends TestNGSuite {
   @DataProvider(name = "calendars") private[chrono] def data_of_calendars: Array[Array[Chronology]] = {
     Array[Array[Chronology]](Array(HijrahChronology.INSTANCE), Array(IsoChronology.INSTANCE), Array(JapaneseChronology.INSTANCE), Array(MinguoChronology.INSTANCE), Array(ThaiBuddhistChronology.INSTANCE))
   }

--- a/src/test/scala/org/threeten/bp/chrono/TestChronology.scala
+++ b/src/test/scala/org/threeten/bp/chrono/TestChronology.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.chrono
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertNotNull
 import org.testng.Assert.assertSame
@@ -49,7 +50,7 @@ import org.threeten.bp.temporal.ChronoField
 /**
   * Test Chrono class.
   */
-@Test class TestChronology {
+@Test class TestChronology extends TestNGSuite {
   @BeforeMethod def setUp(): Unit = {
     var c: Chronology = null
     c = HijrahChronology.INSTANCE

--- a/src/test/scala/org/threeten/bp/chrono/TestHijrahChronology.scala
+++ b/src/test/scala/org/threeten/bp/chrono/TestHijrahChronology.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.chrono
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertFalse
 import org.testng.Assert.assertTrue
@@ -46,7 +47,7 @@ import org.threeten.bp.temporal.TemporalAdjusters
 /**
   * Test.
   */
-@Test class TestHijrahChronology {
+@Test class TestHijrahChronology extends TestNGSuite {
   @Test def test_chrono_byName(): Unit = {
     val c: Chronology = HijrahChronology.INSTANCE
     val test: Chronology = Chronology.of("Hijrah")

--- a/src/test/scala/org/threeten/bp/chrono/TestJapaneseChronology.scala
+++ b/src/test/scala/org/threeten/bp/chrono/TestJapaneseChronology.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.chrono
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertFalse
 import org.testng.Assert.assertTrue
@@ -47,7 +48,7 @@ import org.threeten.bp.temporal.TemporalAdjusters
 /**
   * Test.
   */
-@Test class TestJapaneseChronology {
+@Test class TestJapaneseChronology extends TestNGSuite {
   @Test def test_chrono_byName(): Unit = {
     val c: Chronology = JapaneseChronology.INSTANCE
     val test: Chronology = Chronology.of("Japanese")

--- a/src/test/scala/org/threeten/bp/chrono/TestThaiBuddhistChronology.scala
+++ b/src/test/scala/org/threeten/bp/chrono/TestThaiBuddhistChronology.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.chrono
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertFalse
 import org.testng.Assert.assertTrue
@@ -57,7 +58,7 @@ import org.threeten.bp.temporal.ValueRange
   private val YDIFF: Int = 543
 }
 
-@Test class TestThaiBuddhistChronology {
+@Test class TestThaiBuddhistChronology extends TestNGSuite {
   @Test def test_chrono_byName(): Unit = {
     val c: Chronology = ThaiBuddhistChronology.INSTANCE
     val test: Chronology = Chronology.of("ThaiBuddhist")

--- a/src/test/scala/org/threeten/bp/format/AbstractTestPrinterParser.scala
+++ b/src/test/scala/org/threeten/bp/format/AbstractTestPrinterParser.scala
@@ -32,6 +32,7 @@
 package org.threeten.bp.format
 
 import java.util.Locale
+import org.scalatest.testng.TestNGSuite
 import org.testng.annotations.BeforeMethod
 import org.testng.annotations.Test
 import org.threeten.bp.LocalDateTime
@@ -52,7 +53,7 @@ import org.threeten.bp.temporal.TemporalField
   }
 }
 
-@Test class AbstractTestPrinterParser {
+@Test class AbstractTestPrinterParser extends TestNGSuite {
   protected var printEmptyContext: DateTimePrintContext = null
   protected var printContext: DateTimePrintContext = null
   protected var parseContext: DateTimeParseContext = null

--- a/src/test/scala/org/threeten/bp/format/TestDateTimeBuilderCombinations.scala
+++ b/src/test/scala/org/threeten/bp/format/TestDateTimeBuilderCombinations.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.format
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.threeten.bp.temporal.ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH
 import org.threeten.bp.temporal.ChronoField.ALIGNED_DAY_OF_WEEK_IN_YEAR
@@ -61,7 +62,7 @@ object TestDateTimeBuilderCombinations {
   private val PARIS: ZoneId = ZoneId.of("Europe/Paris")
 }
 
-class TestDateTimeBuilderCombinations {
+class TestDateTimeBuilderCombinations extends TestNGSuite {
   @DataProvider(name = "combine") private[format] def data_combine: Array[Array[Any]] = {
     Array[Array[Any]](Array(YEAR, 2012, MONTH_OF_YEAR, 6, DAY_OF_MONTH, 3, null, null, LocalDate.from _, LocalDate.of(2012, 6, 3)), Array(PROLEPTIC_MONTH, 2012 * 12 + 6 - 1, DAY_OF_MONTH, 3, null, null, null, null, LocalDate.from _, LocalDate.of(2012, 6, 3)), Array(YEAR, 2012, ALIGNED_WEEK_OF_YEAR, 6, DAY_OF_WEEK, 3, null, null, LocalDate.from _, LocalDate.of(2012, 2, 8)), Array(YEAR, 2012, DAY_OF_YEAR, 155, null, null, null, null, LocalDate.from _, LocalDate.of(2012, 6, 3)), Array(EPOCH_DAY, 12, null, null, null, null, null, null, LocalDate.from _, LocalDate.of(1970, 1, 13)))
   }

--- a/src/test/scala/org/threeten/bp/format/TestDateTimeFormatter.scala
+++ b/src/test/scala/org/threeten/bp/format/TestDateTimeFormatter.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.format
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertNull
 import org.testng.Assert.assertTrue
@@ -60,7 +61,7 @@ import org.threeten.bp.temporal.TemporalQuery
   private val DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("'ONE'uuuu MM dd")
 }
 
-@Test class TestDateTimeFormatter {
+@Test class TestDateTimeFormatter extends TestNGSuite {
   private var fmt: DateTimeFormatter = null
 
   @BeforeMethod def setUp(): Unit = {

--- a/src/test/scala/org/threeten/bp/format/TestDateTimeTextPrinting.scala
+++ b/src/test/scala/org/threeten/bp/format/TestDateTimeTextPrinting.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.format
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.threeten.bp.temporal.ChronoField.DAY_OF_MONTH
 import org.threeten.bp.temporal.ChronoField.DAY_OF_WEEK
@@ -46,7 +47,7 @@ import org.threeten.bp.temporal.TemporalField
 /**
   * Test text printing.
   */
-@Test class TestDateTimeTextPrinting {
+@Test class TestDateTimeTextPrinting extends TestNGSuite {
   private var builder: DateTimeFormatterBuilder = null
 
   @BeforeMethod def setUp(): Unit = {

--- a/src/test/scala/org/threeten/bp/format/TestDecimalStyle.scala
+++ b/src/test/scala/org/threeten/bp/format/TestDecimalStyle.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.format
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import java.util.Locale
 import java.util.Set
@@ -39,7 +40,7 @@ import org.testng.annotations.Test
 /**
   * Test DecimalStyle.
   */
-@Test class TestDecimalStyle {
+@Test class TestDecimalStyle extends TestNGSuite {
   @Test def test_getAvailableLocales(): Unit = {
     val locales: java.util.Set[Locale] = DecimalStyle.getAvailableLocales
     assertEquals(locales.size > 0, true)

--- a/src/test/scala/org/threeten/bp/format/TestSimpleDateTimeTextProvider.scala
+++ b/src/test/scala/org/threeten/bp/format/TestSimpleDateTimeTextProvider.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.format
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.threeten.bp.temporal.ChronoField.AMPM_OF_DAY
 import org.threeten.bp.temporal.ChronoField.DAY_OF_WEEK
@@ -44,7 +45,7 @@ import org.threeten.bp.temporal.TemporalField
 /**
   * Test SimpleDateTimeTextProvider.
   */
-@Test class TestSimpleDateTimeTextProvider {
+@Test class TestSimpleDateTimeTextProvider extends TestNGSuite {
   private[format] var enUS: Locale = new Locale("en", "US")
   private[format] var ptBR: Locale = new Locale("pt", "BR")
   private[format] var frFR: Locale = new Locale("fr", "FR")

--- a/src/test/scala/org/threeten/bp/temporal/TestChronoField.scala
+++ b/src/test/scala/org/threeten/bp/temporal/TestChronoField.scala
@@ -31,13 +31,14 @@
  */
 package org.threeten.bp.temporal
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.annotations.Test
 
 /**
   * Test.
   */
-@Test class TestChronoField {
+@Test class TestChronoField extends TestNGSuite {
   @Test def test_isDateBased(): Unit = {
     for (field <- ChronoField.values) {
       if ((field eq ChronoField.INSTANT_SECONDS) || (field eq ChronoField.OFFSET_SECONDS)) {

--- a/src/test/scala/org/threeten/bp/temporal/TestIsoFields.scala
+++ b/src/test/scala/org/threeten/bp/temporal/TestIsoFields.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.temporal
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertTrue
 import org.threeten.bp.DayOfWeek.FRIDAY
@@ -51,7 +52,7 @@ import org.threeten.bp.format.DateTimeFormatterBuilder
 /**
   * Test.
   */
-@Test class TestIsoFields {
+@Test class TestIsoFields extends TestNGSuite {
   def test_enum(): Unit = {
     assertTrue(IsoFields.WEEK_OF_WEEK_BASED_YEAR.isInstanceOf[Enum[_]])
     assertTrue(IsoFields.WEEK_BASED_YEAR.isInstanceOf[Enum[_]])

--- a/src/test/scala/org/threeten/bp/temporal/TestTemporalAdjusters.scala
+++ b/src/test/scala/org/threeten/bp/temporal/TestTemporalAdjusters.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.temporal
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertFalse
 import org.testng.Assert.assertNotNull
@@ -49,7 +50,7 @@ import org.threeten.bp.Month
 /**
   * Test DateTimeAdjusters.
   */
-@Test class TestTemporalAdjusters {
+@Test class TestTemporalAdjusters extends TestNGSuite {
   @Test def factory_firstDayOfMonth(): Unit = {
     assertNotNull(TemporalAdjusters.firstDayOfMonth)
   }

--- a/src/test/scala/org/threeten/bp/temporal/TestValueRange.scala
+++ b/src/test/scala/org/threeten/bp/temporal/TestValueRange.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.temporal
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -43,7 +44,7 @@ import org.threeten.bp.AbstractTest
 /**
   * Test.
   */
-@Test class TestValueRange {
+@Test class TestValueRange extends TestNGSuite {
   @Test def test_immutable(): Unit = {
     AbstractTest.assertImmutable(classOf[ValueRange])
   }

--- a/src/test/scala/org/threeten/bp/zone/TestFixedZoneRules.scala
+++ b/src/test/scala/org/threeten/bp/zone/TestFixedZoneRules.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.zone
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
@@ -57,7 +58,7 @@ import org.threeten.bp.zone.ZoneOffsetTransitionRule.TimeDefinition
   private val INSTANT: Instant = LDT.toInstant(OFFSET_PONE)
 }
 
-@Test class TestFixedZoneRules {
+@Test class TestFixedZoneRules extends TestNGSuite {
   private def make(offset: ZoneOffset): ZoneRules = {
     offset.getRules
   }

--- a/src/test/scala/org/threeten/bp/zone/TestStandardZoneRules.scala
+++ b/src/test/scala/org/threeten/bp/zone/TestStandardZoneRules.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.zone
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertFalse
 import org.testng.Assert.assertNotNull
@@ -66,7 +67,7 @@ import org.threeten.bp.zone.ZoneOffsetTransitionRule.TimeDefinition
   private val GAP: Int = 0
 }
 
-@Test class TestStandardZoneRules {
+@Test class TestStandardZoneRules extends TestNGSuite {
   @throws(classOf[Exception])
   def test_serialization_loaded(): Unit = {
     assertSerialization(europeLondon)

--- a/src/test/scala/org/threeten/bp/zone/TestTzdbZoneRulesCompiler.scala
+++ b/src/test/scala/org/threeten/bp/zone/TestTzdbZoneRulesCompiler.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.zone
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import java.io.File
 import java.lang.reflect.InvocationTargetException
@@ -85,7 +86,7 @@ import org.threeten.bp.zone.ZoneOffsetTransitionRule.TimeDefinition
   }
 }
 
-@Test class TestTzdbZoneRulesCompiler {
+@Test class TestTzdbZoneRulesCompiler extends TestNGSuite {
   @Test
   @throws[Exception]
   def test_parseYear_specific(): Unit = {

--- a/src/test/scala/org/threeten/bp/zone/TestZoneOffsetTransition.scala
+++ b/src/test/scala/org/threeten/bp/zone/TestZoneOffsetTransition.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.zone
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.threeten.bp.temporal.ChronoUnit.HOURS
 import java.io.IOException
@@ -44,7 +45,7 @@ import org.threeten.bp.ZoneOffset
 /**
   * Test ZoneOffsetTransition.
   */
-@Test object TestZoneOffsetTransition {
+@Test object TestZoneOffsetTransition extends TestNGSuite {
   private val OFFSET_0100: ZoneOffset = ZoneOffset.ofHours(1)
   private val OFFSET_0200: ZoneOffset = ZoneOffset.ofHours(2)
   private val OFFSET_0230: ZoneOffset = ZoneOffset.ofHoursMinutes(2, 30)

--- a/src/test/scala/org/threeten/bp/zone/TestZoneOffsetTransitionRule.scala
+++ b/src/test/scala/org/threeten/bp/zone/TestZoneOffsetTransitionRule.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.zone
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import java.io.IOException
 import org.testng.annotations.Test
@@ -45,7 +46,7 @@ import org.threeten.bp.zone.ZoneOffsetTransitionRule.TimeDefinition
 /**
   * Test ZoneOffsetTransitionRule.
   */
-@Test object TestZoneOffsetTransitionRule {
+@Test object TestZoneOffsetTransitionRule extends TestNGSuite {
   private val TIME_0100: LocalTime = LocalTime.of(1, 0)
   private val OFFSET_0200: ZoneOffset = ZoneOffset.ofHours(2)
   private val OFFSET_0300: ZoneOffset = ZoneOffset.ofHours(3)

--- a/src/test/scala/org/threeten/bp/zone/TestZoneRulesBuilder.scala
+++ b/src/test/scala/org/threeten/bp/zone/TestZoneRulesBuilder.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.zone
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertNotNull
 import org.threeten.bp.DayOfWeek.FRIDAY
@@ -97,7 +98,7 @@ import org.threeten.bp.ZoneOffset
   def dateTime(year: Int, month: Month, day: Int, h: Int, m: Int): LocalDateTime = LocalDateTime.of(year, month, day, h, m)
 }
 
-@Test class TestZoneRulesBuilder {
+@Test class TestZoneRulesBuilder extends TestNGSuite {
   @Test(expectedExceptions = Array(classOf[IllegalStateException])) def test_toRules_noWindows(): Unit = {
     val b: ZoneRulesBuilder = new ZoneRulesBuilder
     b.toRules("Europe/London")

--- a/src/test/scala/org/threeten/bp/zone/TestZoneRulesProvider.scala
+++ b/src/test/scala/org/threeten/bp/zone/TestZoneRulesProvider.scala
@@ -31,6 +31,7 @@
  */
 package org.threeten.bp.zone
 
+import org.scalatest.testng.TestNGSuite
 import org.testng.Assert.assertEquals
 import org.testng.Assert.assertNotNull
 import org.testng.Assert.assertTrue
@@ -66,7 +67,7 @@ import org.threeten.bp.ZoneOffset
 
 }
 
-@Test class TestZoneRulesProvider {
+@Test class TestZoneRulesProvider extends TestNGSuite {
   @Test def test_getAvailableGroupIds(): Unit = {
     val zoneIds: java.util.Set[String] = ZoneRulesProvider.getAvailableZoneIds
     assertEquals(zoneIds.contains("Europe/London"), true)


### PR DESCRIPTION
This is a basic sbt config that also builds under scala.js and adjusts the tests to run under scalatest.