### PR TITLE
Simplify invalid temporal units constructor

### DIFF
--- a/src/test/scala/org/threeten/bp/TestLocalTime.scala
+++ b/src/test/scala/org/threeten/bp/TestLocalTime.scala
@@ -93,8 +93,7 @@ import org.threeten.bp.temporal.UnsupportedTemporalTypeException
   private val INVALID_UNITS: Array[TemporalUnit] =  {
     // FIXME: Following line workarounds the test with the invalid units but the actual fix should be done in the ChronoUnit class
     //ChronoUnit.values.filter(unit => unit.ordinal() >= WEEKS.ordinal() && unit.ordinal() <= FOREVER.ordinal()).asInstanceOf[Array[TemporalUnit]]
-    val set: java.util.EnumSet[ChronoUnit] = EnumSet.range(WEEKS, FOREVER)
-    set.toArray(new Array[TemporalUnit](set.size)).asInstanceOf[Array[TemporalUnit]]
+    Array(WEEKS, FOREVER)
   }
 }
 
@@ -195,7 +194,7 @@ import org.threeten.bp.temporal.UnsupportedTemporalTypeException
     val zone: ZoneId = ZoneId.of("UTC+01:02:03")
     var expected: LocalTime = LocalTime.now(Clock.system(zone))
     var test: LocalTime = LocalTime.now(zone)
-    
+
     {
       var i: Int = 0
       while (i < 100) {
@@ -571,7 +570,7 @@ import org.threeten.bp.temporal.UnsupportedTemporalTypeException
 
   @Test def test_withHour_normal(): Unit = {
     var t: LocalTime = TEST_12_30_40_987654321
-    
+
     {
       var i: Int = 0
       while (i < 24) {
@@ -612,7 +611,7 @@ import org.threeten.bp.temporal.UnsupportedTemporalTypeException
 
   @Test def test_withMinute_normal(): Unit = {
     var t: LocalTime = TEST_12_30_40_987654321
-    
+
     {
       var i: Int = 0
       while (i < 60) {
@@ -653,7 +652,7 @@ import org.threeten.bp.temporal.UnsupportedTemporalTypeException
 
   @Test def test_withSecond_normal(): Unit = {
     var t: LocalTime = TEST_12_30_40_987654321
-    
+
     {
       var i: Int = 0
       while (i < 60) {


### PR DESCRIPTION
- Fixes failing invalid unit tests